### PR TITLE
add dark mode

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,13 +12,13 @@
     <div id="docketBody">
         <div id="navBar">
             <header>Docket > 
-                <h3 id="fileName" contenteditable="true"></h3>
+                <h3 id="fileName" contenteditable="true"></h3> 
             </header>
             <div id="noteOptions">
                 <button id="newNoteButton">📝</button>
                 <button id="deleteNoteButton">🗑️</button>
             </div>
-            <div id="savedNotes"></div>
+            <div id="savedNotes" style="cursor: pointer;"></div>
         </div>
         <textarea title="Input" id="mdEditor" class="bodyText" spellcheck="false"></textarea>
         <div class="verticalLine"></div>

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -39,7 +39,6 @@ textarea:focus {
 #navBar {
     /* flex-grow: 0.5; */
     width: 150px;
-    background-color: #f6f8fa;
     padding: 10px;
 }
 
@@ -150,4 +149,18 @@ textarea:focus {
 .popup {
     width: 400px;
     overflow-y: hidden;
+}
+
+.dark {
+    background-color: #1e1e1e;
+    color: #f6f8fa;
+}
+
+.dark-navbar {
+    background-color: #2e2e2e;
+    color: #f6f8fa;
+}
+
+.light-navbar {
+    background-color: #f6f8fa;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,12 @@ hljs.registerLanguage('plaintext', plaintext)
 hljs.registerLanguage('rust', rust)
 hljs.registerLanguage('typescript', typescript)
 
+const uiTheme = localStorage.getItem("ui-theme") ?? "light";
+
+document.body.classList.add(uiTheme);
+document.getElementById("navBar")?.classList.add(uiTheme + "-navbar");
+document.getElementById("mdEditor")?.classList.add(uiTheme);
+
 // Marked object
 const marked = new Marked(
     {


### PR DESCRIPTION
- adds a local storage key to store UI theme as either `dark` or `light`
- it is light mode by default, no way to change the theme through the UI, must do so in dev tools
- adds class names to relevant elements to make them dark mode when the theme is dark

![image](https://github.com/LordExodius/docket/assets/34012681/9bca4dfc-f843-49d7-90b7-964f9ba453f6)
