### PR TITLE
fix unintended margin after ol/ul p list items

### DIFF
--- a/dist/markdown.css
+++ b/dist/markdown.css
@@ -61,7 +61,9 @@ hr,
 ol ol,
 ol ul,
 ul ol,
-ul ul {
+ul ul,
+ol p,
+ul p {
   margin: 0;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "docket",
     "description": "markdown editor tab",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "chrome_url_overrides": {
         "newtab": "dist/index.html"
     },


### PR DESCRIPTION
## Describe your changes
<!--- If this fixes an open issue, please link to the issue here. -->
- remove unintended margin after `ol/ul p` list items

## Checklist
- [x] I have compiled the code before submitting the PR (Run `npm run build`)
- [x] Works on my machine 🥱
- [x] I bumped the version number accordingly
